### PR TITLE
Fix out of range temperature and humidity values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,31 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Added
-
-- New features that have been added
+## [0.2.0] - 2026-01-02
 
 ### Changed
 
-- Changes to existing functionality
+- **BREAKING**: Renamed `FLOOR_SENSOR_NOT_ATTACHED` constant to `INT16_SENSOR_NOT_ATTACHED` and `CO2_SENSOR_NOT_EQUIPPED` constant to `UINT16_SENSOR_NOT_ATTACHED` to make data types explicit
+- `temp_air` and `temp_floor` fields in `ThermostatStatus` now return `None` when sensor value equals `INT16_SENSOR_NOT_ATTACHED` (32767)
+- `co2` and `hum_air` fields in `ThermostatStatus` now return `None` when sensor value equals `UINT16_SENSOR_NOT_ATTACHED` (65535)
+- Updated type hints: `temp_air`, `hum_air`, `temp_floor`, and `co2` are now `float | None` or `int | None` instead of `float` or `int`
+- Replaced `asyncio.timeout` with aiohttp's native `ClientTimeout` for more idiomatic and efficient timeout handling
 
-### Deprecated
+### Added
 
-- Features that will be removed in upcoming releases
-
-### Removed
-
-- Features that have been removed
-
-### Fixed
-
-- Bug fixes
-
-### Security
-
-- Security improvements
+- Test coverage for air temperature sensor not attached scenario
+- Test coverage for humidity sensor not attached scenario
 
 ## [0.1.0] - 2025-10-30
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyairobotrest"
-version = "0.1.0"
+version = "0.2.0"
 description = "Python library for Airobot thermostat TE1 local REST API"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/pyairobotrest/const.py
+++ b/src/pyairobotrest/const.py
@@ -16,8 +16,8 @@ METHOD_GET = "GET"
 METHOD_POST = "POST"
 
 # Value constants
-FLOOR_SENSOR_NOT_ATTACHED = 32767
-CO2_SENSOR_NOT_EQUIPPED = 65535
+INT16_SENSOR_NOT_ATTACHED = 32767  # Signed 16-bit max (temperature sensors)
+UINT16_SENSOR_NOT_ATTACHED = 65535  # Unsigned 16-bit max (CO2/humidity sensors)
 
 # Temperature limits (in 0.1°C units as per API)
 MIN_TEMP_RAW = 50  # 5.0°C
@@ -63,7 +63,6 @@ MODE_MIN = 1  # HOME mode
 MODE_MAX = 2  # AWAY mode
 MODE_HOME = 1
 MODE_AWAY = 2
-MODE_DEFAULT = 1  # HOME mode default
 
 # Setpoint temperature ranges (in 0.1°C units as per API)
 # Both HOME and AWAY temperatures have same range: 50-350 (5.0°C - 35.0°C)


### PR DESCRIPTION
Fix https://github.com/mettolen/pyairobotrest/issues/1

### Changed

- **BREAKING**: Renamed `FLOOR_SENSOR_NOT_ATTACHED` constant to `INT16_SENSOR_NOT_ATTACHED` and `CO2_SENSOR_NOT_EQUIPPED` constant to `UINT16_SENSOR_NOT_ATTACHED` to make data types explicit
- `temp_air` and `temp_floor` fields in `ThermostatStatus` now return `None` when sensor value equals `INT16_SENSOR_NOT_ATTACHED` (32767)
- `co2` and `hum_air` fields in `ThermostatStatus` now return `None` when sensor value equals `UINT16_SENSOR_NOT_ATTACHED` (65535)
- Updated type hints: `temp_air`, `hum_air`, `temp_floor`, and `co2` are now `float | None` or `int | None` instead of `float` or `int`
- Replaced `asyncio.timeout` with aiohttp's native `ClientTimeout` for more idiomatic and efficient timeout handling

### Added

- Test coverage for air temperature sensor not attached scenario
- Test coverage for humidity sensor not attached scenario